### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Uses `yt-dlp` to download subtitles from YouTube and connects it to claude.ai via [Model Context Protocol](https://modelcontextprotocol.io/introduction). Try it by asking Claude, "Summarize the YouTube video <<URL>>". Requires `yt-dlp` to be installed locally e.g. via Homebrew.
 
+<a href="https://glama.ai/mcp/servers/bdr6u8668a"><img width="380" height="200" src="https://glama.ai/mcp/servers/bdr6u8668a/badge" alt="@kazuph/mcp-youtube MCP server" /></a>
+
 ### How do I get this working?
 
 Install `yt-dlp` (Homebrew and WinGet both work great here)


### PR DESCRIPTION
This PR adds a badge for the @kazuph/mcp-youtube server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/bdr6u8668a"><img width="380" height="200" src="https://glama.ai/mcp/servers/bdr6u8668a/badge" alt="@kazuph/mcp-youtube MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.