### PR TITLE
chore: cut 1.0.5 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kazuph/mcp-youtube",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kazuph/mcp-youtube",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kazuph/mcp-youtube",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Model Context Protocol server for YouTube - Extract subtitles from YouTube videos for Claude",
   "author": "kazuph (https://x.com/kazuph)",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary\n- bump package version to 1.0.5 for publishing\n\n## Testing\n- npm version patch --no-git-tag-version